### PR TITLE
Correct recovery rate formula

### DIFF
--- a/streamdeck-coronavirus/Actions/CoronavirusCountryStatsAction.cs
+++ b/streamdeck-coronavirus/Actions/CoronavirusCountryStatsAction.cs
@@ -145,14 +145,16 @@ namespace BarRaider.Coronavirus
             }
 
 
-            if (!long.TryParse(stats.Deaths, out long deaths) || !long.TryParse(stats.Cases, out long allCases))
+            if (!long.TryParse(stats.Recovered, out long recovered) || 
+                !long.TryParse(stats.Deaths, out long deaths) ||
+                !long.TryParse(stats.Cases, out long allCases))
             {
                 Logger.Instance.LogMessage(TracingLevel.WARN, $"CoronavirusCountryStatsAction > Could not convert deaths/all cases to integer Deaths: {stats.Deaths} Case: {stats.Cases}");
                 return;
             }
 
             // Get the recovery rate as a percentage
-            double recoveryRate = (1 - ((double)deaths / (double)allCases)) * 100;
+            double recoveryRate = (double)recovered / (double)allCases * 100;
             using (Bitmap img = Tools.GenerateGenericKeyImage(out Graphics graphics))
             {
                 graphics.PageUnit = GraphicsUnit.Pixel;

--- a/streamdeck-coronavirus/Actions/CoronavirusWorldwideStatsAction.cs
+++ b/streamdeck-coronavirus/Actions/CoronavirusWorldwideStatsAction.cs
@@ -108,14 +108,16 @@ namespace BarRaider.Coronavirus
                 return;
             }
 
-            if (!long.TryParse(stats.Deaths, out long deaths) || !long.TryParse(stats.AllCases, out long allCases))
+            if (!long.TryParse(stats.Recovered, out long recovered) || 
+                !long.TryParse(stats.Deaths, out long deaths) ||
+                !long.TryParse(stats.AllCases, out long allCases))
             {
                 Logger.Instance.LogMessage(TracingLevel.WARN, $"CoronavirusWorldwideStatsAction > Could not convert deaths/all cases to integer Deaths: {stats.Deaths} All Case: {stats.AllCases}");
                 return;
             }
             
             // Get the recovery rate as a percentage
-            double recoveryRate = (1 - ((double)deaths / (double)allCases)) * 100;
+            double recoveryRate = (double)recovered / (double)allCases * 100;
             using (Bitmap img = Tools.GenerateGenericKeyImage(out Graphics graphics))
             {
                 int height = img.Height;


### PR DESCRIPTION
The recovery rate looks exceptionally high. It seems that the current algorithm is "1-deaths/allCases". Since the source data has the number of recovered people, I'm proposing "recovered/allCases" instead.