### PR TITLE
👽 Updated API to v3 (v2 soon to be deprecated)

### DIFF
--- a/Coronavirus/Backend/CovidDataManager.cs
+++ b/Coronavirus/Backend/CovidDataManager.cs
@@ -19,7 +19,7 @@ namespace BarRaider.Coronavirus.Backend
         private static CovidDataManager instance = null;
         private static readonly object objLock = new object();
 
-        private const string COVID_API_SITE = "https://corona.lmao.ninja/v2/";
+        private const string COVID_API_SITE = "https://disease.sh/v3/covid-19/";
         private const string API_WORLDWIDE = "all";
         private const string API_COUNTRIES = "countries";
         private const int REFRESH_RATE_SECONDS = 600;


### PR DESCRIPTION
NovelCOVID has re-branded to disease.sh as they no-longer only support COVID-19 but Influenza too.